### PR TITLE
[#12] variables에 대해 no-use-before-define 설정 끄기

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,5 +12,11 @@ module.exports = {
   rules: {
     'react-refresh/only-export-components': 'warn',
     'linebreak-style': 0,
+    'no-use-before-define': [
+      'error',
+      {
+        variables: false,
+      },
+    ],
   },
 };


### PR DESCRIPTION
### 이슈번호
#12 
### 개요(간단한 작업 내용 설명)
Styled Component를 사용되는 곳보다 밑에 선언할 때 에러가 발생하여 해당 설정을 OFF

### 작업한 내용
 variables에 대해 no-use-before-define 설정 끄기 - [db29f6](https://github.com/thinkingPotatoes/FRONTEND/commit/db29f65cbd748a2ff0464cc9de3d6118cd13ba00)

개인적으로는 Styled Component는 스타일과 관련된 부분이라서 컴포넌트의 핵심 로직이 먼저 나와야한다고 생각해서 컴포넌트 밑에 작성합니다. 그래서 type - component - style 이런 형태로 작성하는데 이 부분도 의견 남겨주시면 될 것 같습니다!