### PR TITLE
[#41] blog 페이지 chip props 에러 해결

### DIFF
--- a/src/components/blog/BlogReviewSection.tsx
+++ b/src/components/blog/BlogReviewSection.tsx
@@ -16,13 +16,13 @@ function BlogReviewSection() {
       <ViewSelector>
         <ViewToggle
           onClick={() => handleSelectViewType(VIEW_CALENDAR)}
-          isSelected={viewType === VIEW_CALENDAR}
+          $isSelected={viewType === VIEW_CALENDAR}
         >
           Calendar
         </ViewToggle>
         <ViewToggle
           onClick={() => handleSelectViewType(VIEW_LIST)}
-          isSelected={viewType === VIEW_LIST}
+          $isSelected={viewType === VIEW_LIST}
         >
           List
         </ViewToggle>
@@ -56,7 +56,7 @@ const ViewSelector = styled.div`
   background: var(--dark-bg-default, #111213);
 `;
 
-const ViewToggle = styled.span<{ isSelected: boolean }>`
+const ViewToggle = styled.span<{ $isSelected: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -65,9 +65,9 @@ const ViewToggle = styled.span<{ isSelected: boolean }>`
   border-radius: 20px;
   background: var(--dark-bg-up, #1c1c25);
 
-  background: ${(props) => (props.isSelected ? '#1c1c25' : '0')};
+  background: ${(props) => (props.$isSelected ? '#1c1c25' : '0')};
 
-  color: ${(props) => (props.isSelected ? '#fff' : '#7E7E87')};
+  color: ${(props) => (props.$isSelected ? '#fff' : '#7E7E87')};
 
   /* Subtitle2 */
   font-size: 14px;

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -8,18 +8,13 @@ function Blog() {
     <BlogWrapper>
       <BlogInfoWrapper>
         <BlogInfo>
-          <BlogTitle>
-            {'하둘셋넷다여일여아열하둘셋넷다여일여아열하둘셋넷다여'}
-          </BlogTitle>
+          <BlogTitle>{'하둘셋넷다여일여아열하둘셋넷다여일여아열하둘셋넷다여'}</BlogTitle>
           <ChipWrapper>
-            <Chip
-              props={{ text: '드라마', deletable: false, bgColor: 'gray' }}
-            />
+            <Chip props={{ text: '드라마', deletable: false }} />
             <Chip
               props={{
                 text: '멜로 / 로멘스',
                 deletable: false,
-                bgColor: 'gray',
               }}
             />
           </ChipWrapper>


### PR DESCRIPTION
### 이슈번호

#41 

### 개요(간단한 작업 내용 설명)

blog 페이지 chip props 에러 해결

### 스크린 샷 및 화면(뷰 개발시 필수)

뷰 없음

### 작업한 내용

- chip props에서 bgColor 제거: 32d503f33f90d05b88d4f53f3244f85ccde2e1c3
- ViewToggle 스타일 컴포넌트 props 변수명 수정: 95c91edfbcaf434eb9300f6cb3bf94466823dfdb

close #41 
